### PR TITLE
Fix: 헤더에 z-index 값을 줘서 검색 페이지에서 검색 input이 헤더 침범하는 현상 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 const Header = () => {
   return (
-    <header className="bg-white shadow-sm fixed sm:relative w-full">
+    <header className="bg-white shadow-sm fixed sm:relative w-full z-10">
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         <Link href="/" className="text-xl font-semibold">
           <Home className="block sm:hidden" />


### PR DESCRIPTION
1. [Fix: 헤더에 z-index 값을 줘서 검색 페이지에서 검색 input이 헤더 침범하는 현상 수정](https://github.com/jihohub/weather/commit/b967502c823af35508e9d6c2044a604059998c9d)